### PR TITLE
Revert aws-sdk client updates from 3.23.0 back to 3.22.0

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -88,12 +88,12 @@
       }
     },
     "@aws-sdk/abort-controller": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.23.0.tgz",
-      "integrity": "sha512-M69Sdoi6TH2UrnXKKNJNDaW6iCqpras7w274CZq4NjFOGwrb23KO2Aexgxr3g3hsUidfjuA38oFbHgC8odFrIQ==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.22.0.tgz",
+      "integrity": "sha512-vrzYpzW+tVMjxXSnu2Uy8/nWMbmc/EwD1+J7c1w3e6Ys7Qlujd0EgdkihLIlxahcdizeuIq4XNRu49rz0LdZCQ==",
       "requires": {
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -104,130 +104,646 @@
       }
     },
     "@aws-sdk/chunked-blob-reader": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.23.0.tgz",
-      "integrity": "sha512-gmJhCuXrKOOumppviE4K30NvsIQIqqxbGDNptrJrMYBO0qXCbK8/BypZ/hS/oT3loDzlSIxG2z5GDL/va9lbFw==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.22.0.tgz",
+      "integrity": "sha512-J0Hf9kCK/W8SH31x3OExflbCubqePmEGqM6Jejd8AZI91YWYESktm4jpY7X0FjZDZj/WORXjYv/wGBiRnBqZ/A==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       }
     },
     "@aws-sdk/chunked-blob-reader-native": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.23.0.tgz",
-      "integrity": "sha512-Ya5f8Ntv0EyZw+AHkpV6n6qqHzpCDNlkX50uj/dwFCMmPiHFWsWMvd0Qu04Y7miycJINEatRrJ5V8r/uVvZIDg==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.22.0.tgz",
+      "integrity": "sha512-tZaqtTYTOxc94tbNHGVpgSxaaqr8TQ+nrGdwDxOyFY0JifHYESyfqy+RMX+10YLhAEEuOsCvzrkpyTDaXoEUkw==",
       "requires": {
-        "@aws-sdk/util-base64-browser": "3.23.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/util-base64-browser": "3.22.0",
+        "tslib": "^2.0.0"
       }
     },
     "@aws-sdk/client-dynamodb": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.23.0.tgz",
-      "integrity": "sha512-qHbyd9bubC6MtV1eOX7yYn26KZhVjlSExE9Np6A3mLHhlMmTFsEJOgTFKH9j3DlE2fZ6a+q3ftP/bjgNdJ5LBw==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.22.0.tgz",
+      "integrity": "sha512-6K/f44H9WF0MNwy5jw7826SpWU3O1tTQwJhZoCyHYKumK/nEW/2/dz6b4ckeabhVC0PjSYKIE9k26APlhObe2A==",
       "requires": {
         "@aws-crypto/sha256-browser": "^1.0.0",
         "@aws-crypto/sha256-js": "^1.0.0",
-        "@aws-sdk/client-sts": "3.23.0",
-        "@aws-sdk/config-resolver": "3.23.0",
-        "@aws-sdk/credential-provider-node": "3.23.0",
-        "@aws-sdk/fetch-http-handler": "3.23.0",
-        "@aws-sdk/hash-node": "3.23.0",
-        "@aws-sdk/invalid-dependency": "3.23.0",
-        "@aws-sdk/middleware-content-length": "3.23.0",
-        "@aws-sdk/middleware-endpoint-discovery": "3.23.0",
-        "@aws-sdk/middleware-host-header": "3.23.0",
-        "@aws-sdk/middleware-logger": "3.23.0",
-        "@aws-sdk/middleware-retry": "3.23.0",
-        "@aws-sdk/middleware-serde": "3.23.0",
-        "@aws-sdk/middleware-signing": "3.23.0",
-        "@aws-sdk/middleware-stack": "3.23.0",
-        "@aws-sdk/middleware-user-agent": "3.23.0",
-        "@aws-sdk/node-config-provider": "3.23.0",
-        "@aws-sdk/node-http-handler": "3.23.0",
-        "@aws-sdk/protocol-http": "3.23.0",
-        "@aws-sdk/smithy-client": "3.23.0",
+        "@aws-sdk/client-sts": "3.22.0",
+        "@aws-sdk/config-resolver": "3.22.0",
+        "@aws-sdk/credential-provider-node": "3.22.0",
+        "@aws-sdk/fetch-http-handler": "3.22.0",
+        "@aws-sdk/hash-node": "3.22.0",
+        "@aws-sdk/invalid-dependency": "3.22.0",
+        "@aws-sdk/middleware-content-length": "3.22.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.22.0",
+        "@aws-sdk/middleware-host-header": "3.22.0",
+        "@aws-sdk/middleware-logger": "3.22.0",
+        "@aws-sdk/middleware-retry": "3.22.0",
+        "@aws-sdk/middleware-serde": "3.22.0",
+        "@aws-sdk/middleware-signing": "3.22.0",
+        "@aws-sdk/middleware-stack": "3.22.0",
+        "@aws-sdk/middleware-user-agent": "3.22.0",
+        "@aws-sdk/node-config-provider": "3.22.0",
+        "@aws-sdk/node-http-handler": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/smithy-client": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "@aws-sdk/url-parser": "3.23.0",
-        "@aws-sdk/util-base64-browser": "3.23.0",
-        "@aws-sdk/util-base64-node": "3.23.0",
-        "@aws-sdk/util-body-length-browser": "3.23.0",
-        "@aws-sdk/util-body-length-node": "3.23.0",
-        "@aws-sdk/util-user-agent-browser": "3.23.0",
-        "@aws-sdk/util-user-agent-node": "3.23.0",
-        "@aws-sdk/util-utf8-browser": "3.23.0",
-        "@aws-sdk/util-utf8-node": "3.23.0",
-        "@aws-sdk/util-waiter": "3.23.0",
-        "tslib": "^2.3.0",
+        "@aws-sdk/url-parser": "3.22.0",
+        "@aws-sdk/util-base64-browser": "3.22.0",
+        "@aws-sdk/util-base64-node": "3.22.0",
+        "@aws-sdk/util-body-length-browser": "3.22.0",
+        "@aws-sdk/util-body-length-node": "3.22.0",
+        "@aws-sdk/util-user-agent-browser": "3.22.0",
+        "@aws-sdk/util-user-agent-node": "3.22.0",
+        "@aws-sdk/util-utf8-browser": "3.22.0",
+        "@aws-sdk/util-utf8-node": "3.22.0",
+        "@aws-sdk/util-waiter": "3.22.0",
+        "tslib": "^2.0.0",
         "uuid": "^8.3.2"
       },
       "dependencies": {
+        "@aws-sdk/abort-controller": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.22.0.tgz",
+          "integrity": "sha512-vrzYpzW+tVMjxXSnu2Uy8/nWMbmc/EwD1+J7c1w3e6Ys7Qlujd0EgdkihLIlxahcdizeuIq4XNRu49rz0LdZCQ==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.22.0.tgz",
+          "integrity": "sha512-LXskY6Mvo/wk2dL1FNTazzhWiHiI3+nJdAT7iNOAg2Q1EUGVAfK+6EccEFPqaBtJDN4kv047HxXNVXKxJSyICg==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "^1.0.0",
+            "@aws-crypto/sha256-js": "^1.0.0",
+            "@aws-sdk/config-resolver": "3.22.0",
+            "@aws-sdk/fetch-http-handler": "3.22.0",
+            "@aws-sdk/hash-node": "3.22.0",
+            "@aws-sdk/invalid-dependency": "3.22.0",
+            "@aws-sdk/middleware-content-length": "3.22.0",
+            "@aws-sdk/middleware-host-header": "3.22.0",
+            "@aws-sdk/middleware-logger": "3.22.0",
+            "@aws-sdk/middleware-retry": "3.22.0",
+            "@aws-sdk/middleware-serde": "3.22.0",
+            "@aws-sdk/middleware-stack": "3.22.0",
+            "@aws-sdk/middleware-user-agent": "3.22.0",
+            "@aws-sdk/node-config-provider": "3.22.0",
+            "@aws-sdk/node-http-handler": "3.22.0",
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/smithy-client": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/url-parser": "3.22.0",
+            "@aws-sdk/util-base64-browser": "3.22.0",
+            "@aws-sdk/util-base64-node": "3.22.0",
+            "@aws-sdk/util-body-length-browser": "3.22.0",
+            "@aws-sdk/util-body-length-node": "3.22.0",
+            "@aws-sdk/util-user-agent-browser": "3.22.0",
+            "@aws-sdk/util-user-agent-node": "3.22.0",
+            "@aws-sdk/util-utf8-browser": "3.22.0",
+            "@aws-sdk/util-utf8-node": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.22.0.tgz",
+          "integrity": "sha512-3htpVHnnD4AvHPo+8VfkPbegN4WPAqcNIXPKCMNkNbYmnLLbtB4MlzKsRgpBP4LvRhi/2kt8fapRTQuTXo/8Mg==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "^1.0.0",
+            "@aws-crypto/sha256-js": "^1.0.0",
+            "@aws-sdk/config-resolver": "3.22.0",
+            "@aws-sdk/credential-provider-node": "3.22.0",
+            "@aws-sdk/fetch-http-handler": "3.22.0",
+            "@aws-sdk/hash-node": "3.22.0",
+            "@aws-sdk/invalid-dependency": "3.22.0",
+            "@aws-sdk/middleware-content-length": "3.22.0",
+            "@aws-sdk/middleware-host-header": "3.22.0",
+            "@aws-sdk/middleware-logger": "3.22.0",
+            "@aws-sdk/middleware-retry": "3.22.0",
+            "@aws-sdk/middleware-sdk-sts": "3.22.0",
+            "@aws-sdk/middleware-serde": "3.22.0",
+            "@aws-sdk/middleware-signing": "3.22.0",
+            "@aws-sdk/middleware-stack": "3.22.0",
+            "@aws-sdk/middleware-user-agent": "3.22.0",
+            "@aws-sdk/node-config-provider": "3.22.0",
+            "@aws-sdk/node-http-handler": "3.22.0",
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/smithy-client": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/url-parser": "3.22.0",
+            "@aws-sdk/util-base64-browser": "3.22.0",
+            "@aws-sdk/util-base64-node": "3.22.0",
+            "@aws-sdk/util-body-length-browser": "3.22.0",
+            "@aws-sdk/util-body-length-node": "3.22.0",
+            "@aws-sdk/util-user-agent-browser": "3.22.0",
+            "@aws-sdk/util-user-agent-node": "3.22.0",
+            "@aws-sdk/util-utf8-browser": "3.22.0",
+            "@aws-sdk/util-utf8-node": "3.22.0",
+            "entities": "2.2.0",
+            "fast-xml-parser": "3.19.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.22.0.tgz",
+          "integrity": "sha512-zXKUbEzYeeg0eazUwNYK62lBj3sqVaRgUlDdL1+czGU2cnfhjbCGUKun9L+XTVw5Cu6V1y4cWYrA03e/2Ugl4g==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.22.0.tgz",
+          "integrity": "sha512-vbM4hcH28fyos2BAtt1ANhEEZynYpFgdMTdw2d8jJMDITE4gtMzomVOdz/7ZVf9WFUJf9iYV6U3fXSqalFeeew==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.22.0.tgz",
+          "integrity": "sha512-d1nAy6OM+7+Yat5Yx0u5r2lRZxcCaxykblDO2rcicdsINxxcSglQsD4pud3t/dfyUfkrnznlNE5VY0H+90kx8g==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.22.0.tgz",
+          "integrity": "sha512-uq9vn+qNmhBNaWu1CkuLKAKJPce7h2O8uuDRLwPfk5zWhLgeW1pjGyMyG+8aX1nytzNH+TXL+GvkMHf/Qzn11w==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.22.0",
+            "@aws-sdk/credential-provider-imds": "3.22.0",
+            "@aws-sdk/credential-provider-sso": "3.22.0",
+            "@aws-sdk/credential-provider-web-identity": "3.22.0",
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/shared-ini-file-loader": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-credentials": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.22.0.tgz",
+          "integrity": "sha512-A3MONEY+Ul9gB2whV69n5V2sMeVXXYVA1MejG3v51d7csEi/XNlBQK5IfhEur6qi49km84xVsfHdO5/a/DNTqg==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.22.0",
+            "@aws-sdk/credential-provider-imds": "3.22.0",
+            "@aws-sdk/credential-provider-ini": "3.22.0",
+            "@aws-sdk/credential-provider-process": "3.22.0",
+            "@aws-sdk/credential-provider-sso": "3.22.0",
+            "@aws-sdk/credential-provider-web-identity": "3.22.0",
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/shared-ini-file-loader": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.22.0.tgz",
+          "integrity": "sha512-5glIbC8jTiiBEMZnsX8KN9m3IC9EdVOj8H+DavwHpTv801j27NhuNYwR2JOLxhjW+PiNX1iyA5k7wfUlLJultQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/shared-ini-file-loader": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-credentials": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.22.0.tgz",
+          "integrity": "sha512-lgqvFIJctJmD2kjWY/BjXdKhH2Fndj/8CPRTDs8ja9AOXU/C3ExnDA15vqhDm5JvKmlkafQEtmypg5n+AZCwSw==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.22.0",
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/shared-ini-file-loader": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-credentials": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.22.0.tgz",
+          "integrity": "sha512-4CTVRuh3EMbH+EYtY0balZ+05BvjcTcW+n0uISK4a4KSMvVBWbhmiIm3U5ducPZfKAenf2mS0UHYRmV/nRLJzA==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.22.0.tgz",
+          "integrity": "sha512-LFp/dkRwPceIXODin+0YtfzWyt+rjgr59C8BsgT2x3aZJ9rBTnAHSr8Bp0UBMqm6F9lOodf4jqa40xsw6MAiGw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/querystring-builder": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-base64-browser": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.22.0.tgz",
+          "integrity": "sha512-AlNdW3P3lzu2PNtVxhMw5i6hD8n7LUiOXGkU88IItv7vRd8a4ntURod8FCzDT1VkLlNKH4+lkXmCu8/uCTfLHA==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-buffer-from": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.22.0.tgz",
+          "integrity": "sha512-8Y1LnS9izRgje7TYAsTPa1xTBXBY++YfxLrTEF1PUDtjgjeBHYN6bVIXT2YFp8D/GGl523fd1QyA4DS476Ptwg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.22.0.tgz",
+          "integrity": "sha512-VVok7FHxuQr7GmyC6ZfiEavXc1Xeyyz7O62YfsOdQz61nSKEX9V8Eopeq6i4boIOHoBQZA9FpFwyODOFSkEcQA==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.22.0.tgz",
+          "integrity": "sha512-2kNiq/Ny3TN3sP6oPJDOB/0m7JOfWXpGdZBcYB9aSQ2LybsN4Yg2RISBnKUxAW8O5sfrzXVn+ZeLFa9+QUY7hQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.22.0.tgz",
+          "integrity": "sha512-cksE9UrbPtv8Qld7YNIDNZ7uXXTK0fMBEzk21IZ/6rv/2wPWoCfiUzAg4CCk1e3WH7WyOhw4ysRG2CuRxJ7zLg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.22.0.tgz",
+          "integrity": "sha512-fXVCEZteSK5ltyJANS0X9zq/CY1hQIQmemsDST66qM+UaAZzEYPNE/3p7skjADkBEz/9++KRYmMuoSjumPholg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.22.0.tgz",
+          "integrity": "sha512-BQ3DgqvOG7fiIfxd5k9l93S2r0XraIrioqYYvxuABtt08dV+iwPNFDPIYYTkPV8Tp6Pvu4Hzjn1pQzGYiatjnQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/service-error-classification": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.22.0.tgz",
+          "integrity": "sha512-CpfPpKTKEcxyooDwa7tFZDhhB3RwByxwzQ+jEAUcDvSLRALyNb1jvwAfgJJQBx6uZgqj97Z46UYpMJIDoCebTA==",
+          "requires": {
+            "@aws-sdk/middleware-signing": "3.22.0",
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/signature-v4": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.22.0.tgz",
+          "integrity": "sha512-5ie2XvwFSHpRDmsCqmQ3VmwGnnFE3E+ptjGEbo8GXNJHrvX3apDgjGFSyLUNS/Ezv1FkUFm0qcs4rgxYCW8dNg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.22.0.tgz",
+          "integrity": "sha512-8cyfXJhy1cPyOiM/Wv7hIA5N7UZZ6fK/9jxH0I4gTH8c35frZqS2uUaSGj3eJrKvuXKLeSdKKwYsCU21CjLbqQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/signature-v4": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.22.0.tgz",
+          "integrity": "sha512-acG5h6aDSiIjWvmeiTwsZthlafOiL27k7fIvmlim/VRomzAxPBazXYQMzhKBRhki7KP4iIu8ZEOBZuWeNQNGHg==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.22.0.tgz",
+          "integrity": "sha512-+iFu5CIPE3/KX9bxD1cC8n3uqWm+vUk46fIdYzz3It0OoWcx9JRVsHU3nu0dlJa9rZoWwLt/PVM9qExI+fQdXg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.22.0.tgz",
+          "integrity": "sha512-OOUqFMHaV7JgDCbpC4G0VYFSwG4Y/8TV5cJFj/Xsx4MhhSc0Hcm2GAJ+gshrCwPq0yeLKOxaFGdaLxemWgk4ug==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.22.0",
+            "@aws-sdk/shared-ini-file-loader": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.22.0.tgz",
+          "integrity": "sha512-lYZf7g8Y5URb2U0BYZz4mYRNt9pR3DYljIIET8ac3ZmiIOXnDogVHtT6S3Cw+tA9biWhm+tbJRP8sE8nEgMIfw==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.22.0",
+            "@aws-sdk/protocol-http": "3.22.0",
+            "@aws-sdk/querystring-builder": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.22.0.tgz",
+          "integrity": "sha512-2Su5F0AUq1RqGgjlnOzYBa9XFSBXD4sSTR+duN4dwkstXsNU/Ozuon9xeTEzW+BqRZbqdCPkut+ms/hh5nEZFg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.22.0.tgz",
+          "integrity": "sha512-mlkQhw0pJ/QVy/Cz7XCmEKlkdKl5qfTvDe6dnRTtFqbVDypaehlG4rMYNYwBgDRHbHyHdWYQbapk3cQfc4NiLA==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.22.0.tgz",
+          "integrity": "sha512-ZIjM0m/VdVc5HlQeg9MxRFa8kyo45OIDktUrNcHRz4m7umgS6NCAqY6/+58QNxXYUy7LR83JF9A5oDglvpV8Dw==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-uri-escape": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.22.0.tgz",
+          "integrity": "sha512-OeDue0/krnIKuDHDpJbWGjmDsQfh+Z9dSlfBs2x+V9hIdm3k1s/vl36z3sFnhxcHYvf79UO5hXhbhFDsOWnRsg==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.22.0.tgz",
+          "integrity": "sha512-6ytFFoU8guAljwpmQTvZNf//cTurdumeLlAmQ8RJsbX3y5DGlpG2dfq7mpYJudtJtCQTwPYtaG5Xva460T2CqA=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.22.0.tgz",
+          "integrity": "sha512-qLTSqjqFc98POGg0W+VsWdDcO/6lMHDB5wAvjULIQ+ra93FybL0jG6eA8Ds1CJ8Ibz446l25P0QZsNHkpKX2EA==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.22.0.tgz",
+          "integrity": "sha512-rh25sQ/+5KJSz6+tTRVwbmKpcH9bgkoMw48Vu0xXdTrbPKaO8Kya5E9TM/8+PUZfRtIHU/R1LJJZkoY23awOTg==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-hex-encoding": "3.22.0",
+            "@aws-sdk/util-uri-escape": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.22.0.tgz",
+          "integrity": "sha512-/xW5ClxSfLUiQFAOFD7H17f57t7tTFNulipSpvI4jWAFyrIbuSAWcR/8f2+iuz2jbteEj1Ik3c5+7AFXPLqgew==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
         "@aws-sdk/types": {
           "version": "3.22.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.22.0.tgz",
           "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ=="
         },
-        "@aws-sdk/util-utf8-browser": {
-          "version": "3.23.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.23.0.tgz",
-          "integrity": "sha512-fSB95AKnvCnAbCd7o0xLbErfAgD9wnLCaEu23AgfGAiaG3nFF8Z2+wtjebU/9Z4RI9d/x83Ho/yguRnJdkMsPA==",
+        "@aws-sdk/url-parser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.22.0.tgz",
+          "integrity": "sha512-zHI3GUC0ftsmrFi+9jWhwZu9b7Ol2gQDOEVn161HmAc+SnWyRDUJWLrrrJNoYbMO4SoxJiwoM8LIBv/ydRL74Q==",
           "requires": {
-            "tslib": "^2.3.0"
+            "@aws-sdk/querystring-parser": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-base64-browser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.22.0.tgz",
+          "integrity": "sha512-z+CpIMB/mhKmiAz5/YPDGJXHNsdsmJoKeKSHWJqwwqpIlQCrwX55DnOGcIggftqOL23OB+K+E0Z/X/NFGRmFEw==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-base64-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.22.0.tgz",
+          "integrity": "sha512-FJln59hxRIDJofQa+O3RC2SsT0xkaju4FmHY3XTR0O+1x/Qo7/SlAzGm8+F3O5fQyk6XWGV6NpY7/jT4iFe/WQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.22.0.tgz",
+          "integrity": "sha512-CaTvQhp7zq8SYPcCcG1NTYUw/gmz3avxnGGqEsCYU/C3zPczYiqH1e8AixErQSwLKG78lKaDO6DPwmwsheebuw==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.22.0.tgz",
+          "integrity": "sha512-EIfg3PIusUxGwTjTP2O4QVORHkxOw0xub8c1EII++3FPpqWDEl6VUDXbAvJE6SMd0C7UceL6HKjZYKFfx0HbnA==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.22.0.tgz",
+          "integrity": "sha512-9wO2vXY+mH5Fqxf0kxPAJiwKEoy69AA8Srt7B3FeOyhhPAZbSAniS4Kw+I/Ni/5ZyCRyMaKrR31PoDilbana1A==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.22.0.tgz",
+          "integrity": "sha512-fCo2URT8kbyEullWjXrmmqtjDmjIAnwMv6T9GFw4enVARUDNArmxGfi4VK/GQKWAGa9Wd2b74tgDH60yG3qAng==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.22.0.tgz",
+          "integrity": "sha512-SDeYT3qktYGv/9z6nnVRp3VYm/5S/uea4IPUGQlPyea05uOxe/ysqEW4ogve4ugQVgIbE47OvyoZlwFiFgbkVQ==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.22.0.tgz",
+          "integrity": "sha512-FnGmHG986MjFV0FW9WV8DF+DBqieo3Dl4KVg7BQSyOAClN3w8XOBvP8YZlxUtYA3zeVXvHRpJjupgRsq8tZ9jw==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.22.0.tgz",
+          "integrity": "sha512-XuAfkTS8Bl++Fp2rbgyIIs3cCVi6DaTmW/a+OztJx2IOVqTIkjruckhBPCf5/v2coy7xZeD8YqpIJUdcY4w+iw==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.22.0.tgz",
+          "integrity": "sha512-4S1adLvYi5fHTbV4zpC4I4oKku0U1Pc1byfX7iJrWu07TVUeW4YAfwCaLK4O3qUUJZ1mXIqxArRGBFnbhHWeDg==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.22.0.tgz",
+          "integrity": "sha512-uZPhyt/OiSuFwWzBB/OF6ZUNM5cG7kW1U8Cfa740IKZrCNbawRZipiqkKdffAiVTKF3VfOQEbZCJibiD2BfafQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-waiter": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.22.0.tgz",
+          "integrity": "sha512-LIAwm0UsL829REK6Pqd9HKinC6W9akescqfYlraKd26GBssxfm8HFwHBxHK/roOLgJF0sfgZno2r8eCc/T0nzw==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
           }
         }
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.23.0.tgz",
-      "integrity": "sha512-F6nP81HQ4pfZUCmeIHOoiIMm1i9L1lvbSioFZDgN6qFPzSUnbNRMxcgX+Dwwt/WHcf+lx1bVaA6h3U1CTCS93Q==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.22.0.tgz",
+      "integrity": "sha512-RkZEFghW+1fsnbZsZRvBzl5DXjkY8yiJKFhi/RQrhYjxI/BfFql2vaEhlmVuqeo6jqdrCUmBPEuDzEV+5IvKIw==",
       "requires": {
         "@aws-crypto/sha256-browser": "^1.0.0",
         "@aws-crypto/sha256-js": "^1.0.0",
-        "@aws-sdk/client-sts": "3.23.0",
-        "@aws-sdk/config-resolver": "3.23.0",
-        "@aws-sdk/credential-provider-node": "3.23.0",
-        "@aws-sdk/eventstream-serde-browser": "3.23.0",
-        "@aws-sdk/eventstream-serde-config-resolver": "3.23.0",
-        "@aws-sdk/eventstream-serde-node": "3.23.0",
-        "@aws-sdk/fetch-http-handler": "3.23.0",
-        "@aws-sdk/hash-blob-browser": "3.23.0",
-        "@aws-sdk/hash-node": "3.23.0",
-        "@aws-sdk/hash-stream-node": "3.23.0",
-        "@aws-sdk/invalid-dependency": "3.23.0",
-        "@aws-sdk/md5-js": "3.23.0",
-        "@aws-sdk/middleware-apply-body-checksum": "3.23.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.23.0",
-        "@aws-sdk/middleware-content-length": "3.23.0",
-        "@aws-sdk/middleware-expect-continue": "3.23.0",
-        "@aws-sdk/middleware-host-header": "3.23.0",
-        "@aws-sdk/middleware-location-constraint": "3.23.0",
-        "@aws-sdk/middleware-logger": "3.23.0",
-        "@aws-sdk/middleware-retry": "3.23.0",
-        "@aws-sdk/middleware-sdk-s3": "3.23.0",
-        "@aws-sdk/middleware-serde": "3.23.0",
-        "@aws-sdk/middleware-signing": "3.23.0",
-        "@aws-sdk/middleware-ssec": "3.23.0",
-        "@aws-sdk/middleware-stack": "3.23.0",
-        "@aws-sdk/middleware-user-agent": "3.23.0",
-        "@aws-sdk/node-config-provider": "3.23.0",
-        "@aws-sdk/node-http-handler": "3.23.0",
-        "@aws-sdk/protocol-http": "3.23.0",
-        "@aws-sdk/smithy-client": "3.23.0",
+        "@aws-sdk/client-sts": "3.22.0",
+        "@aws-sdk/config-resolver": "3.22.0",
+        "@aws-sdk/credential-provider-node": "3.22.0",
+        "@aws-sdk/eventstream-serde-browser": "3.22.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.22.0",
+        "@aws-sdk/eventstream-serde-node": "3.22.0",
+        "@aws-sdk/fetch-http-handler": "3.22.0",
+        "@aws-sdk/hash-blob-browser": "3.22.0",
+        "@aws-sdk/hash-node": "3.22.0",
+        "@aws-sdk/hash-stream-node": "3.22.0",
+        "@aws-sdk/invalid-dependency": "3.22.0",
+        "@aws-sdk/md5-js": "3.22.0",
+        "@aws-sdk/middleware-apply-body-checksum": "3.22.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.22.0",
+        "@aws-sdk/middleware-content-length": "3.22.0",
+        "@aws-sdk/middleware-expect-continue": "3.22.0",
+        "@aws-sdk/middleware-host-header": "3.22.0",
+        "@aws-sdk/middleware-location-constraint": "3.22.0",
+        "@aws-sdk/middleware-logger": "3.22.0",
+        "@aws-sdk/middleware-retry": "3.22.0",
+        "@aws-sdk/middleware-sdk-s3": "3.22.0",
+        "@aws-sdk/middleware-serde": "3.22.0",
+        "@aws-sdk/middleware-signing": "3.22.0",
+        "@aws-sdk/middleware-ssec": "3.22.0",
+        "@aws-sdk/middleware-stack": "3.22.0",
+        "@aws-sdk/middleware-user-agent": "3.22.0",
+        "@aws-sdk/node-config-provider": "3.22.0",
+        "@aws-sdk/node-http-handler": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/smithy-client": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "@aws-sdk/url-parser": "3.23.0",
-        "@aws-sdk/util-base64-browser": "3.23.0",
-        "@aws-sdk/util-base64-node": "3.23.0",
-        "@aws-sdk/util-body-length-browser": "3.23.0",
-        "@aws-sdk/util-body-length-node": "3.23.0",
-        "@aws-sdk/util-user-agent-browser": "3.23.0",
-        "@aws-sdk/util-user-agent-node": "3.23.0",
-        "@aws-sdk/util-utf8-browser": "3.23.0",
-        "@aws-sdk/util-utf8-node": "3.23.0",
-        "@aws-sdk/util-waiter": "3.23.0",
-        "@aws-sdk/xml-builder": "3.23.0",
+        "@aws-sdk/url-parser": "3.22.0",
+        "@aws-sdk/util-base64-browser": "3.22.0",
+        "@aws-sdk/util-base64-node": "3.22.0",
+        "@aws-sdk/util-body-length-browser": "3.22.0",
+        "@aws-sdk/util-body-length-node": "3.22.0",
+        "@aws-sdk/util-user-agent-browser": "3.22.0",
+        "@aws-sdk/util-user-agent-node": "3.22.0",
+        "@aws-sdk/util-utf8-browser": "3.22.0",
+        "@aws-sdk/util-utf8-node": "3.22.0",
+        "@aws-sdk/util-waiter": "3.22.0",
+        "@aws-sdk/xml-builder": "3.22.0",
         "entities": "2.2.0",
         "fast-xml-parser": "3.19.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -236,48 +752,48 @@
           "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ=="
         },
         "@aws-sdk/util-utf8-browser": {
-          "version": "3.23.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.23.0.tgz",
-          "integrity": "sha512-fSB95AKnvCnAbCd7o0xLbErfAgD9wnLCaEu23AgfGAiaG3nFF8Z2+wtjebU/9Z4RI9d/x83Ho/yguRnJdkMsPA==",
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.22.0.tgz",
+          "integrity": "sha512-4S1adLvYi5fHTbV4zpC4I4oKku0U1Pc1byfX7iJrWu07TVUeW4YAfwCaLK4O3qUUJZ1mXIqxArRGBFnbhHWeDg==",
           "requires": {
-            "tslib": "^2.3.0"
+            "tslib": "^2.0.0"
           }
         }
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.23.0.tgz",
-      "integrity": "sha512-Q4ZC7bKAQrcyyRUGPyzyZoygjocP2MR88TYRyKC/WrAGra8owNts7Dn2jBDHfb/mb/Xb8yRNv87lx51Htl15SQ==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.22.0.tgz",
+      "integrity": "sha512-LXskY6Mvo/wk2dL1FNTazzhWiHiI3+nJdAT7iNOAg2Q1EUGVAfK+6EccEFPqaBtJDN4kv047HxXNVXKxJSyICg==",
       "requires": {
         "@aws-crypto/sha256-browser": "^1.0.0",
         "@aws-crypto/sha256-js": "^1.0.0",
-        "@aws-sdk/config-resolver": "3.23.0",
-        "@aws-sdk/fetch-http-handler": "3.23.0",
-        "@aws-sdk/hash-node": "3.23.0",
-        "@aws-sdk/invalid-dependency": "3.23.0",
-        "@aws-sdk/middleware-content-length": "3.23.0",
-        "@aws-sdk/middleware-host-header": "3.23.0",
-        "@aws-sdk/middleware-logger": "3.23.0",
-        "@aws-sdk/middleware-retry": "3.23.0",
-        "@aws-sdk/middleware-serde": "3.23.0",
-        "@aws-sdk/middleware-stack": "3.23.0",
-        "@aws-sdk/middleware-user-agent": "3.23.0",
-        "@aws-sdk/node-config-provider": "3.23.0",
-        "@aws-sdk/node-http-handler": "3.23.0",
-        "@aws-sdk/protocol-http": "3.23.0",
-        "@aws-sdk/smithy-client": "3.23.0",
+        "@aws-sdk/config-resolver": "3.22.0",
+        "@aws-sdk/fetch-http-handler": "3.22.0",
+        "@aws-sdk/hash-node": "3.22.0",
+        "@aws-sdk/invalid-dependency": "3.22.0",
+        "@aws-sdk/middleware-content-length": "3.22.0",
+        "@aws-sdk/middleware-host-header": "3.22.0",
+        "@aws-sdk/middleware-logger": "3.22.0",
+        "@aws-sdk/middleware-retry": "3.22.0",
+        "@aws-sdk/middleware-serde": "3.22.0",
+        "@aws-sdk/middleware-stack": "3.22.0",
+        "@aws-sdk/middleware-user-agent": "3.22.0",
+        "@aws-sdk/node-config-provider": "3.22.0",
+        "@aws-sdk/node-http-handler": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/smithy-client": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "@aws-sdk/url-parser": "3.23.0",
-        "@aws-sdk/util-base64-browser": "3.23.0",
-        "@aws-sdk/util-base64-node": "3.23.0",
-        "@aws-sdk/util-body-length-browser": "3.23.0",
-        "@aws-sdk/util-body-length-node": "3.23.0",
-        "@aws-sdk/util-user-agent-browser": "3.23.0",
-        "@aws-sdk/util-user-agent-node": "3.23.0",
-        "@aws-sdk/util-utf8-browser": "3.23.0",
-        "@aws-sdk/util-utf8-node": "3.23.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/url-parser": "3.22.0",
+        "@aws-sdk/util-base64-browser": "3.22.0",
+        "@aws-sdk/util-base64-node": "3.22.0",
+        "@aws-sdk/util-body-length-browser": "3.22.0",
+        "@aws-sdk/util-body-length-node": "3.22.0",
+        "@aws-sdk/util-user-agent-browser": "3.22.0",
+        "@aws-sdk/util-user-agent-node": "3.22.0",
+        "@aws-sdk/util-utf8-browser": "3.22.0",
+        "@aws-sdk/util-utf8-node": "3.22.0",
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -286,53 +802,53 @@
           "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ=="
         },
         "@aws-sdk/util-utf8-browser": {
-          "version": "3.23.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.23.0.tgz",
-          "integrity": "sha512-fSB95AKnvCnAbCd7o0xLbErfAgD9wnLCaEu23AgfGAiaG3nFF8Z2+wtjebU/9Z4RI9d/x83Ho/yguRnJdkMsPA==",
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.22.0.tgz",
+          "integrity": "sha512-4S1adLvYi5fHTbV4zpC4I4oKku0U1Pc1byfX7iJrWu07TVUeW4YAfwCaLK4O3qUUJZ1mXIqxArRGBFnbhHWeDg==",
           "requires": {
-            "tslib": "^2.3.0"
+            "tslib": "^2.0.0"
           }
         }
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.23.0.tgz",
-      "integrity": "sha512-rF5YpfLw0DhP2ev4xKPoEvvZ3/KoahvlqrTst8VSbz08mI7qCOb2akGgN+6BUgaK4x9S/Suwq30HrFtbp1qjKA==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.22.0.tgz",
+      "integrity": "sha512-3htpVHnnD4AvHPo+8VfkPbegN4WPAqcNIXPKCMNkNbYmnLLbtB4MlzKsRgpBP4LvRhi/2kt8fapRTQuTXo/8Mg==",
       "requires": {
         "@aws-crypto/sha256-browser": "^1.0.0",
         "@aws-crypto/sha256-js": "^1.0.0",
-        "@aws-sdk/config-resolver": "3.23.0",
-        "@aws-sdk/credential-provider-node": "3.23.0",
-        "@aws-sdk/fetch-http-handler": "3.23.0",
-        "@aws-sdk/hash-node": "3.23.0",
-        "@aws-sdk/invalid-dependency": "3.23.0",
-        "@aws-sdk/middleware-content-length": "3.23.0",
-        "@aws-sdk/middleware-host-header": "3.23.0",
-        "@aws-sdk/middleware-logger": "3.23.0",
-        "@aws-sdk/middleware-retry": "3.23.0",
-        "@aws-sdk/middleware-sdk-sts": "3.23.0",
-        "@aws-sdk/middleware-serde": "3.23.0",
-        "@aws-sdk/middleware-signing": "3.23.0",
-        "@aws-sdk/middleware-stack": "3.23.0",
-        "@aws-sdk/middleware-user-agent": "3.23.0",
-        "@aws-sdk/node-config-provider": "3.23.0",
-        "@aws-sdk/node-http-handler": "3.23.0",
-        "@aws-sdk/protocol-http": "3.23.0",
-        "@aws-sdk/smithy-client": "3.23.0",
+        "@aws-sdk/config-resolver": "3.22.0",
+        "@aws-sdk/credential-provider-node": "3.22.0",
+        "@aws-sdk/fetch-http-handler": "3.22.0",
+        "@aws-sdk/hash-node": "3.22.0",
+        "@aws-sdk/invalid-dependency": "3.22.0",
+        "@aws-sdk/middleware-content-length": "3.22.0",
+        "@aws-sdk/middleware-host-header": "3.22.0",
+        "@aws-sdk/middleware-logger": "3.22.0",
+        "@aws-sdk/middleware-retry": "3.22.0",
+        "@aws-sdk/middleware-sdk-sts": "3.22.0",
+        "@aws-sdk/middleware-serde": "3.22.0",
+        "@aws-sdk/middleware-signing": "3.22.0",
+        "@aws-sdk/middleware-stack": "3.22.0",
+        "@aws-sdk/middleware-user-agent": "3.22.0",
+        "@aws-sdk/node-config-provider": "3.22.0",
+        "@aws-sdk/node-http-handler": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/smithy-client": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "@aws-sdk/url-parser": "3.23.0",
-        "@aws-sdk/util-base64-browser": "3.23.0",
-        "@aws-sdk/util-base64-node": "3.23.0",
-        "@aws-sdk/util-body-length-browser": "3.23.0",
-        "@aws-sdk/util-body-length-node": "3.23.0",
-        "@aws-sdk/util-user-agent-browser": "3.23.0",
-        "@aws-sdk/util-user-agent-node": "3.23.0",
-        "@aws-sdk/util-utf8-browser": "3.23.0",
-        "@aws-sdk/util-utf8-node": "3.23.0",
+        "@aws-sdk/url-parser": "3.22.0",
+        "@aws-sdk/util-base64-browser": "3.22.0",
+        "@aws-sdk/util-base64-node": "3.22.0",
+        "@aws-sdk/util-body-length-browser": "3.22.0",
+        "@aws-sdk/util-body-length-node": "3.22.0",
+        "@aws-sdk/util-user-agent-browser": "3.22.0",
+        "@aws-sdk/util-user-agent-node": "3.22.0",
+        "@aws-sdk/util-utf8-browser": "3.22.0",
+        "@aws-sdk/util-utf8-node": "3.22.0",
         "entities": "2.2.0",
         "fast-xml-parser": "3.19.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -341,23 +857,23 @@
           "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ=="
         },
         "@aws-sdk/util-utf8-browser": {
-          "version": "3.23.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.23.0.tgz",
-          "integrity": "sha512-fSB95AKnvCnAbCd7o0xLbErfAgD9wnLCaEu23AgfGAiaG3nFF8Z2+wtjebU/9Z4RI9d/x83Ho/yguRnJdkMsPA==",
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.22.0.tgz",
+          "integrity": "sha512-4S1adLvYi5fHTbV4zpC4I4oKku0U1Pc1byfX7iJrWu07TVUeW4YAfwCaLK4O3qUUJZ1mXIqxArRGBFnbhHWeDg==",
           "requires": {
-            "tslib": "^2.3.0"
+            "tslib": "^2.0.0"
           }
         }
       }
     },
     "@aws-sdk/config-resolver": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.23.0.tgz",
-      "integrity": "sha512-acCxrAymwx81XELBO/d1VBWaHOldxqbmxDAMfvOfUYN+CYXWIFYpY1VCWuAeWig7Dy18QEJQ2pHwQlFxmilA7w==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.22.0.tgz",
+      "integrity": "sha512-zXKUbEzYeeg0eazUwNYK62lBj3sqVaRgUlDdL1+czGU2cnfhjbCGUKun9L+XTVw5Cu6V1y4cWYrA03e/2Ugl4g==",
       "requires": {
-        "@aws-sdk/signature-v4": "3.23.0",
+        "@aws-sdk/signature-v4": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -368,13 +884,13 @@
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.23.0.tgz",
-      "integrity": "sha512-ljYkVATha4BdecVvYeW1WuzoAAwfM/i7p9Wmx1RY3Rb0AGwIFX2GjtoBPhS3EbCRTzQIhUr4zfIelVVVxIS6bA==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.22.0.tgz",
+      "integrity": "sha512-vbM4hcH28fyos2BAtt1ANhEEZynYpFgdMTdw2d8jJMDITE4gtMzomVOdz/7ZVf9WFUJf9iYV6U3fXSqalFeeew==",
       "requires": {
-        "@aws-sdk/property-provider": "3.23.0",
+        "@aws-sdk/property-provider": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -385,13 +901,13 @@
       }
     },
     "@aws-sdk/credential-provider-imds": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.23.0.tgz",
-      "integrity": "sha512-jD1EkoVDApKZJwOLACTrnxhDmQiVF1qMM+GMnoY4bMk1p1sfZYNKs6VkaY2LGUWXxkesj1aiMFxbwyWmu8SQbQ==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.22.0.tgz",
+      "integrity": "sha512-d1nAy6OM+7+Yat5Yx0u5r2lRZxcCaxykblDO2rcicdsINxxcSglQsD4pud3t/dfyUfkrnznlNE5VY0H+90kx8g==",
       "requires": {
-        "@aws-sdk/property-provider": "3.23.0",
+        "@aws-sdk/property-provider": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -402,52 +918,43 @@
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.23.0.tgz",
-      "integrity": "sha512-n1h2YcuZ0ghpoNAYWc8VkVxYamQEBeHUbdfEVVJHsfSon+FBk5gI8V9IZm3xrLHQYwWBDMS/VxeIyKpWnduG9Q==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.22.0.tgz",
+      "integrity": "sha512-uq9vn+qNmhBNaWu1CkuLKAKJPce7h2O8uuDRLwPfk5zWhLgeW1pjGyMyG+8aX1nytzNH+TXL+GvkMHf/Qzn11w==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.23.0",
-        "@aws-sdk/credential-provider-imds": "3.23.0",
-        "@aws-sdk/credential-provider-sso": "3.23.0",
-        "@aws-sdk/credential-provider-web-identity": "3.23.0",
-        "@aws-sdk/property-provider": "3.23.0",
-        "@aws-sdk/shared-ini-file-loader": "3.23.0",
+        "@aws-sdk/credential-provider-env": "3.22.0",
+        "@aws-sdk/credential-provider-imds": "3.22.0",
+        "@aws-sdk/credential-provider-sso": "3.22.0",
+        "@aws-sdk/credential-provider-web-identity": "3.22.0",
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "@aws-sdk/util-credentials": "3.23.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/util-credentials": "3.22.0",
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
           "version": "3.22.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.22.0.tgz",
           "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ=="
-        },
-        "@aws-sdk/util-credentials": {
-          "version": "3.23.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.23.0.tgz",
-          "integrity": "sha512-6TDGZnFa0kZr+vSsWXXMfWt347jbMGKtzGnBxbrmiQgZMijz9s/wLYxsjglZ+CyqI/QrSMOTtqy6mEgJxdnGWQ==",
-          "requires": {
-            "@aws-sdk/shared-ini-file-loader": "3.23.0",
-            "tslib": "^2.3.0"
-          }
         }
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.23.0.tgz",
-      "integrity": "sha512-wbYNUNMNZ+nCZamAc77yLkiO0Lq2isldkkLuQsjerhB9gN0/LBeWVPf6381d5wQN5Q/o7/XEdew0QDB5i0KmIw==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.22.0.tgz",
+      "integrity": "sha512-A3MONEY+Ul9gB2whV69n5V2sMeVXXYVA1MejG3v51d7csEi/XNlBQK5IfhEur6qi49km84xVsfHdO5/a/DNTqg==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.23.0",
-        "@aws-sdk/credential-provider-imds": "3.23.0",
-        "@aws-sdk/credential-provider-ini": "3.23.0",
-        "@aws-sdk/credential-provider-process": "3.23.0",
-        "@aws-sdk/credential-provider-sso": "3.23.0",
-        "@aws-sdk/credential-provider-web-identity": "3.23.0",
-        "@aws-sdk/property-provider": "3.23.0",
-        "@aws-sdk/shared-ini-file-loader": "3.23.0",
+        "@aws-sdk/credential-provider-env": "3.22.0",
+        "@aws-sdk/credential-provider-imds": "3.22.0",
+        "@aws-sdk/credential-provider-ini": "3.22.0",
+        "@aws-sdk/credential-provider-process": "3.22.0",
+        "@aws-sdk/credential-provider-sso": "3.22.0",
+        "@aws-sdk/credential-provider-web-identity": "3.22.0",
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -458,70 +965,52 @@
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.23.0.tgz",
-      "integrity": "sha512-xba0u86nS5MtH3FQKSbTOEaoHjqpoj6NyonZEy0O5i9KO0NHf+bZwlmI/pe54SOE9uSrDKHfXB6dsftVIqXtFQ==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.22.0.tgz",
+      "integrity": "sha512-5glIbC8jTiiBEMZnsX8KN9m3IC9EdVOj8H+DavwHpTv801j27NhuNYwR2JOLxhjW+PiNX1iyA5k7wfUlLJultQ==",
       "requires": {
-        "@aws-sdk/property-provider": "3.23.0",
-        "@aws-sdk/shared-ini-file-loader": "3.23.0",
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "@aws-sdk/util-credentials": "3.23.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/util-credentials": "3.22.0",
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
           "version": "3.22.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.22.0.tgz",
           "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ=="
-        },
-        "@aws-sdk/util-credentials": {
-          "version": "3.23.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.23.0.tgz",
-          "integrity": "sha512-6TDGZnFa0kZr+vSsWXXMfWt347jbMGKtzGnBxbrmiQgZMijz9s/wLYxsjglZ+CyqI/QrSMOTtqy6mEgJxdnGWQ==",
-          "requires": {
-            "@aws-sdk/shared-ini-file-loader": "3.23.0",
-            "tslib": "^2.3.0"
-          }
         }
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.23.0.tgz",
-      "integrity": "sha512-5EXX505eSBN0GQcyO3lFDSU5btJc5aHgp9HJ7jFUqPn0OeNCtLepckuijzKC8cM11C3f2i1CCP/nn6II/fajew==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.22.0.tgz",
+      "integrity": "sha512-lgqvFIJctJmD2kjWY/BjXdKhH2Fndj/8CPRTDs8ja9AOXU/C3ExnDA15vqhDm5JvKmlkafQEtmypg5n+AZCwSw==",
       "requires": {
-        "@aws-sdk/client-sso": "3.23.0",
-        "@aws-sdk/property-provider": "3.23.0",
-        "@aws-sdk/shared-ini-file-loader": "3.23.0",
+        "@aws-sdk/client-sso": "3.22.0",
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "@aws-sdk/util-credentials": "3.23.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/util-credentials": "3.22.0",
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
           "version": "3.22.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.22.0.tgz",
           "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ=="
-        },
-        "@aws-sdk/util-credentials": {
-          "version": "3.23.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.23.0.tgz",
-          "integrity": "sha512-6TDGZnFa0kZr+vSsWXXMfWt347jbMGKtzGnBxbrmiQgZMijz9s/wLYxsjglZ+CyqI/QrSMOTtqy6mEgJxdnGWQ==",
-          "requires": {
-            "@aws-sdk/shared-ini-file-loader": "3.23.0",
-            "tslib": "^2.3.0"
-          }
         }
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.23.0.tgz",
-      "integrity": "sha512-GbDw2izWfb4KG62V6MBTOKmDAhbexbemxJsR0rMlZxW/dEYQh/r8Nk+m7evAUakNMJGm4fcAZGxey+orReq1VQ==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.22.0.tgz",
+      "integrity": "sha512-4CTVRuh3EMbH+EYtY0balZ+05BvjcTcW+n0uISK4a4KSMvVBWbhmiIm3U5ducPZfKAenf2mS0UHYRmV/nRLJzA==",
       "requires": {
-        "@aws-sdk/property-provider": "3.23.0",
+        "@aws-sdk/property-provider": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -532,23 +1021,23 @@
       }
     },
     "@aws-sdk/endpoint-cache": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.23.0.tgz",
-      "integrity": "sha512-Yhe1JvrTEA+BQuT/wfwvYDMqozB4GKXVRA4ZzU5VhkvMwbWd7/xGzDLQ0JG7jtYX3TwRYsBLI1XdQ1oYG3bmrQ==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.22.0.tgz",
+      "integrity": "sha512-TNkkwvuyJSe4W8CR6lyCSK44Gv0FITxOWU52qDal8uLrwPG+wv6Nk77H7pJo/fObY32OVr0EvF9zGEhy7qgsjg==",
       "requires": {
         "mnemonist": "0.38.3",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       }
     },
     "@aws-sdk/eventstream-marshaller": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.23.0.tgz",
-      "integrity": "sha512-gtxdB8/68ZePM1+nZnjZw2OBXB845SPQWnkNRyw2J6Vhlo4uFRYM9W+E/UEuTmGJ/EScnZAJOvegoFYz46CUDQ==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.22.0.tgz",
+      "integrity": "sha512-U+6+jCaIbeNn9c9duIrWaX8+giglaTH1okgLwoKzOZowoGVyGDyjZhXoVao/Furq66UnZfrakPUm9ECcauxAyw==",
       "requires": {
         "@aws-crypto/crc32": "^1.0.0",
         "@aws-sdk/types": "3.22.0",
-        "@aws-sdk/util-hex-encoding": "3.23.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/util-hex-encoding": "3.22.0",
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -559,14 +1048,14 @@
       }
     },
     "@aws-sdk/eventstream-serde-browser": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.23.0.tgz",
-      "integrity": "sha512-DdHNmW+LU7oIsoKkiWlVQ3nNgw6g4QbZRoY1XExb/R1FgGWZ2JXKWEgblZwbaFxnEdD4wD7Tb1dmiwfSIpz2Zg==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.22.0.tgz",
+      "integrity": "sha512-dDhErSf2F9rOmPvdohwA17HX1bRrBApn28xt5cKwOy1fSbKV0x0OA1XShylfxiIAOJoCDsXEBNIsV6DoHLMTnw==",
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.23.0",
-        "@aws-sdk/eventstream-serde-universal": "3.23.0",
+        "@aws-sdk/eventstream-marshaller": "3.22.0",
+        "@aws-sdk/eventstream-serde-universal": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -577,12 +1066,12 @@
       }
     },
     "@aws-sdk/eventstream-serde-config-resolver": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.23.0.tgz",
-      "integrity": "sha512-jedPrTVr73Uu869D/Bs9fL/dM//ScEXEKkjJwv/FJtxTmO6ytpdy6pbwwuvqrcLWjYWJoj9+ABVTsTZxr+TqHw==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.22.0.tgz",
+      "integrity": "sha512-9VzLN/DzrixIE0c2ne2fpT69BSwb0Gfd1iGAGcxJAVrXun1R5u8pSbCagFLAOQWoqtgWP5bNZBkBMfQs+KiymA==",
       "requires": {
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -593,14 +1082,14 @@
       }
     },
     "@aws-sdk/eventstream-serde-node": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.23.0.tgz",
-      "integrity": "sha512-NR1HjoQiWM4FaLTtv47TdXoLQZ+f5m0SU8LNi2dheZlaLHtvssoOOmBbWg+SXOqmW2v4wjRGUFX6SG1qYOai+A==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.22.0.tgz",
+      "integrity": "sha512-IP31m/F7vP7tpN6eRjs9XbqMTmt47X3OCyUDLhKjDaqU0ICCiRSWnCrFPztiJ9BFDp/Y12q9q/0eVzQ0JqMsew==",
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.23.0",
-        "@aws-sdk/eventstream-serde-universal": "3.23.0",
+        "@aws-sdk/eventstream-marshaller": "3.22.0",
+        "@aws-sdk/eventstream-serde-universal": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -611,13 +1100,13 @@
       }
     },
     "@aws-sdk/eventstream-serde-universal": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.23.0.tgz",
-      "integrity": "sha512-vn0qdlmh2qk8QxTRj9CVUQN+lrxz7zufCvVpsK/TEhkpV2+t1PwaGYIPnUeD9OcjrnMR9twiiiWp5fyBRmJbHg==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.22.0.tgz",
+      "integrity": "sha512-BzQ8jAFQUtGWkpkbERZLfixJVujzqlywtiGS2t7rBdlQBL5HV/wnynDRnl7VN2z/DhfY/NONYuGInuRxwZUcFw==",
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.23.0",
+        "@aws-sdk/eventstream-marshaller": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -628,15 +1117,15 @@
       }
     },
     "@aws-sdk/fetch-http-handler": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.23.0.tgz",
-      "integrity": "sha512-gjToPkLlVOO8bHKhyw+d4mIX4OJEabqIFYbRFRDSm11LVLAAEc4pIFPYpMNWzrmDEnCxoGAcqfzP0m+0jChVCw==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.22.0.tgz",
+      "integrity": "sha512-LFp/dkRwPceIXODin+0YtfzWyt+rjgr59C8BsgT2x3aZJ9rBTnAHSr8Bp0UBMqm6F9lOodf4jqa40xsw6MAiGw==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.23.0",
-        "@aws-sdk/querystring-builder": "3.23.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/querystring-builder": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "@aws-sdk/util-base64-browser": "3.23.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/util-base64-browser": "3.22.0",
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -647,14 +1136,14 @@
       }
     },
     "@aws-sdk/hash-blob-browser": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.23.0.tgz",
-      "integrity": "sha512-2oY8mSnr3cxmMA/ZTI/1ABbJ0t+BAGUkxys+9nrE6XTlzrpJqsCL8b2dmARD2iSMZaUGP24QB3cIvcwC6IwNWg==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.22.0.tgz",
+      "integrity": "sha512-72Pd5z6FiP1Aqb4BQ8w3rtCpVJBbhYgVwk4yzMO35yZBoKQBCXsF7HSKYZDl4PlWVEs7xV9sM7kjJBmXt+klew==",
       "requires": {
-        "@aws-sdk/chunked-blob-reader": "3.23.0",
-        "@aws-sdk/chunked-blob-reader-native": "3.23.0",
+        "@aws-sdk/chunked-blob-reader": "3.22.0",
+        "@aws-sdk/chunked-blob-reader-native": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -665,13 +1154,13 @@
       }
     },
     "@aws-sdk/hash-node": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.23.0.tgz",
-      "integrity": "sha512-yah+vNhKv6jpJR5qHYGc/AIAWwR9Ah9NplAq8cltMsPuI38u/aSlbcEIDwsRz3V1MDA89f/+qY3OHBfQw5kLVw==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.22.0.tgz",
+      "integrity": "sha512-AlNdW3P3lzu2PNtVxhMw5i6hD8n7LUiOXGkU88IItv7vRd8a4ntURod8FCzDT1VkLlNKH4+lkXmCu8/uCTfLHA==",
       "requires": {
         "@aws-sdk/types": "3.22.0",
-        "@aws-sdk/util-buffer-from": "3.23.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/util-buffer-from": "3.22.0",
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -682,12 +1171,12 @@
       }
     },
     "@aws-sdk/hash-stream-node": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.23.0.tgz",
-      "integrity": "sha512-n2WiYIkioYpgleJck23b3zB38wptc5xzKvC/by52tpMrYvkwM6RkwodVQ1aXFfCrTS78ZDnVNBUK2fxDkphfWw==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.22.0.tgz",
+      "integrity": "sha512-suailUkbSgvdUWJYchvn5FLD1J2bOPapRPmlovY6/6ZS/a8CROThIjDag85b8jwH/0E3DeOMpY/ngb0Me56MJw==",
       "requires": {
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -698,12 +1187,12 @@
       }
     },
     "@aws-sdk/invalid-dependency": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.23.0.tgz",
-      "integrity": "sha512-5VqL7crIEtXj+lBwh3kKdMMlejjumjJQ5uLYNSCE/jNS5YjnbhAfO+fyzMO50IhcSuG4Ev6i1DEezN9BmYdeXA==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.22.0.tgz",
+      "integrity": "sha512-8Y1LnS9izRgje7TYAsTPa1xTBXBY++YfxLrTEF1PUDtjgjeBHYN6bVIXT2YFp8D/GGl523fd1QyA4DS476Ptwg==",
       "requires": {
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -714,21 +1203,21 @@
       }
     },
     "@aws-sdk/is-array-buffer": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.23.0.tgz",
-      "integrity": "sha512-XN20/scFthok0lCbjtinW77CoIBoar8cbOzmu+HkYTnBBpJrF6Ai5g9sgglO8r+X+OLn4PrDrTP+BxdpNuIh9g==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.22.0.tgz",
+      "integrity": "sha512-VVok7FHxuQr7GmyC6ZfiEavXc1Xeyyz7O62YfsOdQz61nSKEX9V8Eopeq6i4boIOHoBQZA9FpFwyODOFSkEcQA==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       }
     },
     "@aws-sdk/md5-js": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.23.0.tgz",
-      "integrity": "sha512-XXVuVMJlrWfI+NZ0k1g2gctPHm62BcPD+y0Lr61uC5tG99tMTN2vPC4+65I6AAktXX4Z7i6M89M2A8XkEwri4Q==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.22.0.tgz",
+      "integrity": "sha512-on6MZFs62+TCkdpEB520J8VyXoQvcOMT6gYFKsiPEcQvSbVkwNXS66xr6z72ohCWOeJ+f3Ia2UAoupBP5xc1dg==",
       "requires": {
         "@aws-sdk/types": "3.22.0",
-        "@aws-sdk/util-utf8-browser": "3.23.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/util-utf8-browser": "3.22.0",
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -737,24 +1226,24 @@
           "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ=="
         },
         "@aws-sdk/util-utf8-browser": {
-          "version": "3.23.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.23.0.tgz",
-          "integrity": "sha512-fSB95AKnvCnAbCd7o0xLbErfAgD9wnLCaEu23AgfGAiaG3nFF8Z2+wtjebU/9Z4RI9d/x83Ho/yguRnJdkMsPA==",
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.22.0.tgz",
+          "integrity": "sha512-4S1adLvYi5fHTbV4zpC4I4oKku0U1Pc1byfX7iJrWu07TVUeW4YAfwCaLK4O3qUUJZ1mXIqxArRGBFnbhHWeDg==",
           "requires": {
-            "tslib": "^2.3.0"
+            "tslib": "^2.0.0"
           }
         }
       }
     },
     "@aws-sdk/middleware-apply-body-checksum": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.23.0.tgz",
-      "integrity": "sha512-tu+VsZemq5O9aLH9jDYHq1NFYsR3rCMvSVL9osXrvLwGgnqtE0vwR3myfhw8BF5NTDBckuClES4gPZfzV25F/w==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.22.0.tgz",
+      "integrity": "sha512-kEkn7ayz9N3yms3iUecQX2yuxZ2JIjKG0S+Ri3zZt5uV9E+FgqqXSFtkKVrVNJb3bHK7vQS5wxR0s+P9axNOlA==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.23.0",
-        "@aws-sdk/protocol-http": "3.23.0",
+        "@aws-sdk/is-array-buffer": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -765,14 +1254,14 @@
       }
     },
     "@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.23.0.tgz",
-      "integrity": "sha512-5o6fvarLiNCnWFTs5a0VDfRhGuTm/5exXvZtWU9YIhCNYZEbBCWVFXg6XZ784EH2q1Hj/Tiu8jPa+OM4EQLlhQ==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.22.0.tgz",
+      "integrity": "sha512-UXNKd1/TW/cIaWMHGl0AgubFlzUlxgAwMp1+RBh8n1SWs7uYTB7GirxdLT283vIDf6l5Vrlgn5PxfUB76fUN3w==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.23.0",
+        "@aws-sdk/protocol-http": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "@aws-sdk/util-arn-parser": "3.23.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/util-arn-parser": "3.22.0",
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -783,13 +1272,13 @@
       }
     },
     "@aws-sdk/middleware-content-length": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.23.0.tgz",
-      "integrity": "sha512-ooyNeXZUtI16Qh/HfcwLWn7NB2HvM/XEajaQmVIJXbVy/D2+N82+0Jo2hY3DouuIJjoEv/KZ5Uia/cgCdfHrHQ==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.22.0.tgz",
+      "integrity": "sha512-2kNiq/Ny3TN3sP6oPJDOB/0m7JOfWXpGdZBcYB9aSQ2LybsN4Yg2RISBnKUxAW8O5sfrzXVn+ZeLFa9+QUY7hQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.23.0",
+        "@aws-sdk/protocol-http": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -800,33 +1289,88 @@
       }
     },
     "@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.23.0.tgz",
-      "integrity": "sha512-HNb3IkST42h+Z6z0Jf6/7lXMM/c7cMaHnHPP3lIeRzo/mzz1shxQ8okoGTUU38Gtr3UGZ1KOsLtA6+6a7LitjA==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.22.0.tgz",
+      "integrity": "sha512-OzsXPiyWyC59WjjbisWlg+Y8zxxIEbP8WZZuHrYAVKZP+Xw+HF60Mbc0xKGTgrAotBTM1D8Prae4Cljqx+yflQ==",
       "requires": {
-        "@aws-sdk/config-resolver": "3.23.0",
-        "@aws-sdk/endpoint-cache": "3.23.0",
-        "@aws-sdk/protocol-http": "3.23.0",
+        "@aws-sdk/config-resolver": "3.22.0",
+        "@aws-sdk/endpoint-cache": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
+        "@aws-sdk/config-resolver": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.22.0.tgz",
+          "integrity": "sha512-zXKUbEzYeeg0eazUwNYK62lBj3sqVaRgUlDdL1+czGU2cnfhjbCGUKun9L+XTVw5Cu6V1y4cWYrA03e/2Ugl4g==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.22.0.tgz",
+          "integrity": "sha512-VVok7FHxuQr7GmyC6ZfiEavXc1Xeyyz7O62YfsOdQz61nSKEX9V8Eopeq6i4boIOHoBQZA9FpFwyODOFSkEcQA==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.22.0.tgz",
+          "integrity": "sha512-mlkQhw0pJ/QVy/Cz7XCmEKlkdKl5qfTvDe6dnRTtFqbVDypaehlG4rMYNYwBgDRHbHyHdWYQbapk3cQfc4NiLA==",
+          "requires": {
+            "@aws-sdk/types": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.22.0.tgz",
+          "integrity": "sha512-rh25sQ/+5KJSz6+tTRVwbmKpcH9bgkoMw48Vu0xXdTrbPKaO8Kya5E9TM/8+PUZfRtIHU/R1LJJZkoY23awOTg==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.22.0",
+            "@aws-sdk/types": "3.22.0",
+            "@aws-sdk/util-hex-encoding": "3.22.0",
+            "@aws-sdk/util-uri-escape": "3.22.0",
+            "tslib": "^2.0.0"
+          }
+        },
         "@aws-sdk/types": {
           "version": "3.22.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.22.0.tgz",
           "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ=="
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.22.0.tgz",
+          "integrity": "sha512-fCo2URT8kbyEullWjXrmmqtjDmjIAnwMv6T9GFw4enVARUDNArmxGfi4VK/GQKWAGa9Wd2b74tgDH60yG3qAng==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.22.0.tgz",
+          "integrity": "sha512-SDeYT3qktYGv/9z6nnVRp3VYm/5S/uea4IPUGQlPyea05uOxe/ysqEW4ogve4ugQVgIbE47OvyoZlwFiFgbkVQ==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
         }
       }
     },
     "@aws-sdk/middleware-expect-continue": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.23.0.tgz",
-      "integrity": "sha512-52LNqIfUHVNqaW+WDqDwgt9AD++T9oDO/P5MVLb5MsMVbMYEvTRLu7LZ7iVR4aeWv60CGG87UWGDmX/WhxRmrA==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.22.0.tgz",
+      "integrity": "sha512-vDQDB252YpvnbRnVL+enayokR/anHt2m2cQPWxBZO3bDqKoaTEDbNp4dZw930wxSqSlIBO2Ibhoji0EMD9nXUg==",
       "requires": {
-        "@aws-sdk/middleware-header-default": "3.23.0",
-        "@aws-sdk/protocol-http": "3.23.0",
+        "@aws-sdk/middleware-header-default": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -837,13 +1381,13 @@
       }
     },
     "@aws-sdk/middleware-header-default": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.23.0.tgz",
-      "integrity": "sha512-BW69RRNqWo5sFfGXAojFUMyqvGvG2bbyQk+ZxkWsoXng7LC979YdBJUaVE2C2G6d4ivPpN/SO77ZOZnUaOiHwQ==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.22.0.tgz",
+      "integrity": "sha512-FPk76V7/oC8FkYn14WTtOZcS2SsWrh3n1jzBhnay2IRbpfk1xWeFk1yMjP5sGWrSqllELZxVqxzwP7EgqT4faw==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.23.0",
+        "@aws-sdk/protocol-http": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -854,13 +1398,13 @@
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.23.0.tgz",
-      "integrity": "sha512-bHqQbwY3guUr+AWcrerHIh1ONgqhV8W85+H7MYlt0V5/Kom0+ectR7yZZRt90PDMZ8OsW4+f5jTIURFMLtPbDA==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.22.0.tgz",
+      "integrity": "sha512-cksE9UrbPtv8Qld7YNIDNZ7uXXTK0fMBEzk21IZ/6rv/2wPWoCfiUzAg4CCk1e3WH7WyOhw4ysRG2CuRxJ7zLg==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.23.0",
+        "@aws-sdk/protocol-http": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -871,12 +1415,12 @@
       }
     },
     "@aws-sdk/middleware-location-constraint": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.23.0.tgz",
-      "integrity": "sha512-szytgGt1P4WtoGCiyGw6IRTBN7IFapECzUFLQ3/bz6HgivjnBupDkr1QXjoBy//uMcB+BcFq7DezsbvpfRSuTw==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.22.0.tgz",
+      "integrity": "sha512-OG5TcZO9g5xAheQpVyZj/EgLoBK3aPp+XpBURarQOI3WQ0srtfOAT+k/s1eRUEKjKjleb/Qh28J4GF5zDgVd+A==",
       "requires": {
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -887,12 +1431,12 @@
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.23.0.tgz",
-      "integrity": "sha512-0z0ULcxllHO6xz1VeX/ekmg/LpNFL8nFbRH067s2KaimBeCUZ0CA2RwTpi9IY74tikmZAjerASb8eMgI+L/d7A==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.22.0.tgz",
+      "integrity": "sha512-fXVCEZteSK5ltyJANS0X9zq/CY1hQIQmemsDST66qM+UaAZzEYPNE/3p7skjADkBEz/9++KRYmMuoSjumPholg==",
       "requires": {
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -903,14 +1447,14 @@
       }
     },
     "@aws-sdk/middleware-retry": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.23.0.tgz",
-      "integrity": "sha512-NimiKrP90+aW62QmkOrhQAZjrwjOQuWye2POzdetSrBHpnwj2KQWNBjcRwjkGt53krPcDyCySjIw+ivTRYdxWw==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.22.0.tgz",
+      "integrity": "sha512-BQ3DgqvOG7fiIfxd5k9l93S2r0XraIrioqYYvxuABtt08dV+iwPNFDPIYYTkPV8Tp6Pvu4Hzjn1pQzGYiatjnQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.23.0",
+        "@aws-sdk/protocol-http": "3.22.0",
         "@aws-sdk/service-error-classification": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0",
+        "tslib": "^2.0.0",
         "uuid": "^8.3.2"
       },
       "dependencies": {
@@ -922,14 +1466,14 @@
       }
     },
     "@aws-sdk/middleware-sdk-s3": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.23.0.tgz",
-      "integrity": "sha512-9RwW+Z18wygMYu7HhQGDpU5arqmpu992Q/O8Is6h460vp7JvJ1jZcY2vbJFDz6GdkuDSorRB/XBCxKrcmho3sA==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.22.0.tgz",
+      "integrity": "sha512-btlHsffMhRCx9n6xWt34xTRjNXjgDN+NONgdDchw9oAWdCEaqehcYrTj156WChFuPkof/8NBIGseiz2SfiWL8A==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.23.0",
+        "@aws-sdk/protocol-http": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "@aws-sdk/util-arn-parser": "3.23.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/util-arn-parser": "3.22.0",
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -940,16 +1484,16 @@
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.23.0.tgz",
-      "integrity": "sha512-Rufzuqp4neVsyll9Ya9j+zpoK1fXrujBX6XRR5fRU3SsoAh5YWiUMrkxYxzTN+TLeXmyhCzmH/RuX2hgjMK0VQ==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.22.0.tgz",
+      "integrity": "sha512-CpfPpKTKEcxyooDwa7tFZDhhB3RwByxwzQ+jEAUcDvSLRALyNb1jvwAfgJJQBx6uZgqj97Z46UYpMJIDoCebTA==",
       "requires": {
-        "@aws-sdk/middleware-signing": "3.23.0",
-        "@aws-sdk/property-provider": "3.23.0",
-        "@aws-sdk/protocol-http": "3.23.0",
-        "@aws-sdk/signature-v4": "3.23.0",
+        "@aws-sdk/middleware-signing": "3.22.0",
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/signature-v4": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -960,12 +1504,12 @@
       }
     },
     "@aws-sdk/middleware-serde": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.23.0.tgz",
-      "integrity": "sha512-gNNMOo6Phm/BAnLsXvFfu4PHxKzN1saT3lNkODY2qKB1b4IoFNdMfHMo3jH4sbx7QYoM81qMXKr7aLp1BzTHtw==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.22.0.tgz",
+      "integrity": "sha512-5ie2XvwFSHpRDmsCqmQ3VmwGnnFE3E+ptjGEbo8GXNJHrvX3apDgjGFSyLUNS/Ezv1FkUFm0qcs4rgxYCW8dNg==",
       "requires": {
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -976,15 +1520,15 @@
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.23.0.tgz",
-      "integrity": "sha512-cTozWnc8HLxLjHYU10+uqE4RqXYmmCJqoEKiSzJH7f8n20Pr9ly3rv3/9AfbqPth1PXsg0xHYq/ovCvq6RiaYA==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.22.0.tgz",
+      "integrity": "sha512-8cyfXJhy1cPyOiM/Wv7hIA5N7UZZ6fK/9jxH0I4gTH8c35frZqS2uUaSGj3eJrKvuXKLeSdKKwYsCU21CjLbqQ==",
       "requires": {
-        "@aws-sdk/property-provider": "3.23.0",
-        "@aws-sdk/protocol-http": "3.23.0",
-        "@aws-sdk/signature-v4": "3.23.0",
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/signature-v4": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -995,12 +1539,12 @@
       }
     },
     "@aws-sdk/middleware-ssec": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.23.0.tgz",
-      "integrity": "sha512-SK+HvXoCri0dllcIbWtsbVMf64li8IiT7KnvDbkKRxiO9WFjO70zJ0Ea1REVAXZ1tqAVARMxX/eFvnXOs7Xhhw==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.22.0.tgz",
+      "integrity": "sha512-xS//Rqb1/+1EkSkke0NXCb8hviy7kciDjmoocPt/c61ocX6A2CoLRL8HFJNkWV0O19p7s+4qROkohteFA3dMHg==",
       "requires": {
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -1011,21 +1555,21 @@
       }
     },
     "@aws-sdk/middleware-stack": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.23.0.tgz",
-      "integrity": "sha512-lk4u8wDajJ+VBXVWpzqaRUUJibt1YxsIciwLeZymilAZW5L9VtchUW9fmRpaZX8QHFGGkGuwZjtxlX6MeGXK4w==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.22.0.tgz",
+      "integrity": "sha512-acG5h6aDSiIjWvmeiTwsZthlafOiL27k7fIvmlim/VRomzAxPBazXYQMzhKBRhki7KP4iIu8ZEOBZuWeNQNGHg==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.23.0.tgz",
-      "integrity": "sha512-cwOypi0no2Nsrw1N3VGe/0XgbNl487Wn4jgKZvj+nxdSWh4HQMWpoTLB3YZtzro+J7uVK6X7W+QxBU20+Ypg1g==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.22.0.tgz",
+      "integrity": "sha512-+iFu5CIPE3/KX9bxD1cC8n3uqWm+vUk46fIdYzz3It0OoWcx9JRVsHU3nu0dlJa9rZoWwLt/PVM9qExI+fQdXg==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.23.0",
+        "@aws-sdk/protocol-http": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -1036,14 +1580,14 @@
       }
     },
     "@aws-sdk/node-config-provider": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.23.0.tgz",
-      "integrity": "sha512-OyhyqTXUy5HxPu2c1aCYFHKQGjf4uzjby9AteMhRJfa6cehuVODi3KEv7PyZmJQcYI0Pw9ZnoHqVrTNsUEC2YQ==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.22.0.tgz",
+      "integrity": "sha512-OOUqFMHaV7JgDCbpC4G0VYFSwG4Y/8TV5cJFj/Xsx4MhhSc0Hcm2GAJ+gshrCwPq0yeLKOxaFGdaLxemWgk4ug==",
       "requires": {
-        "@aws-sdk/property-provider": "3.23.0",
-        "@aws-sdk/shared-ini-file-loader": "3.23.0",
+        "@aws-sdk/property-provider": "3.22.0",
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -1054,15 +1598,15 @@
       }
     },
     "@aws-sdk/node-http-handler": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.23.0.tgz",
-      "integrity": "sha512-amvf0lwldUrr+CFtIeMZoNVmv34Fx3zwqobT5WuxtfRWbvSRALMw0LW/oXwoT+4WayM6sIwcIwSG1ZVGCjD0fA==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.22.0.tgz",
+      "integrity": "sha512-lYZf7g8Y5URb2U0BYZz4mYRNt9pR3DYljIIET8ac3ZmiIOXnDogVHtT6S3Cw+tA9biWhm+tbJRP8sE8nEgMIfw==",
       "requires": {
-        "@aws-sdk/abort-controller": "3.23.0",
-        "@aws-sdk/protocol-http": "3.23.0",
-        "@aws-sdk/querystring-builder": "3.23.0",
+        "@aws-sdk/abort-controller": "3.22.0",
+        "@aws-sdk/protocol-http": "3.22.0",
+        "@aws-sdk/querystring-builder": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -1073,12 +1617,12 @@
       }
     },
     "@aws-sdk/property-provider": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.23.0.tgz",
-      "integrity": "sha512-GjFtmFHVzO4BeLRselGirt32cyorP1aRbD+ID4Zhz4RLxa9Nun766s8lqp7EcR/v9pSGdP1Xec3no8ALV3lXmw==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.22.0.tgz",
+      "integrity": "sha512-2Su5F0AUq1RqGgjlnOzYBa9XFSBXD4sSTR+duN4dwkstXsNU/Ozuon9xeTEzW+BqRZbqdCPkut+ms/hh5nEZFg==",
       "requires": {
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -1089,12 +1633,12 @@
       }
     },
     "@aws-sdk/protocol-http": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.23.0.tgz",
-      "integrity": "sha512-JTsq/UU/wTyeCMPVar2xSsMVFf72IK0L7dXbbS7ZHcBV6JAfM/wVTym8/s3mQGM6Kx/c6Wtn+J/5syDx56CV2g==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.22.0.tgz",
+      "integrity": "sha512-mlkQhw0pJ/QVy/Cz7XCmEKlkdKl5qfTvDe6dnRTtFqbVDypaehlG4rMYNYwBgDRHbHyHdWYQbapk3cQfc4NiLA==",
       "requires": {
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -1105,13 +1649,13 @@
       }
     },
     "@aws-sdk/querystring-builder": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.23.0.tgz",
-      "integrity": "sha512-MfQknhgMT9tul0VrxmLBDKlV7Ls2/kEJyprWXUWzCUBMUZ6M+FtOMJhjP90qTbsNvlsEVQgTlS/cDsNVrAUR3A==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.22.0.tgz",
+      "integrity": "sha512-ZIjM0m/VdVc5HlQeg9MxRFa8kyo45OIDktUrNcHRz4m7umgS6NCAqY6/+58QNxXYUy7LR83JF9A5oDglvpV8Dw==",
       "requires": {
         "@aws-sdk/types": "3.22.0",
-        "@aws-sdk/util-uri-escape": "3.23.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/util-uri-escape": "3.22.0",
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -1122,12 +1666,12 @@
       }
     },
     "@aws-sdk/querystring-parser": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.23.0.tgz",
-      "integrity": "sha512-pMEN+rE08QhixRfWEBuQwnOGuGiRjH5++mmyQTUIvEgKk/rnyAkUlrySv775jvrEQlCXH8yqMuHdutF8rHkHGA==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.22.0.tgz",
+      "integrity": "sha512-OeDue0/krnIKuDHDpJbWGjmDsQfh+Z9dSlfBs2x+V9hIdm3k1s/vl36z3sFnhxcHYvf79UO5hXhbhFDsOWnRsg==",
       "requires": {
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -1143,23 +1687,23 @@
       "integrity": "sha512-6ytFFoU8guAljwpmQTvZNf//cTurdumeLlAmQ8RJsbX3y5DGlpG2dfq7mpYJudtJtCQTwPYtaG5Xva460T2CqA=="
     },
     "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.23.0.tgz",
-      "integrity": "sha512-YUp46l6E3dLKHp1cKMkZI4slTjsVc/Lm7nPCTVc3oQvZ1MvC99N/jMCmZ7X5YYofuAUSdc9eJ8sYiF2BnUww9g==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.22.0.tgz",
+      "integrity": "sha512-qLTSqjqFc98POGg0W+VsWdDcO/6lMHDB5wAvjULIQ+ra93FybL0jG6eA8Ds1CJ8Ibz446l25P0QZsNHkpKX2EA==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       }
     },
     "@aws-sdk/signature-v4": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.23.0.tgz",
-      "integrity": "sha512-3smgG/6LcK8SjVqWzroAgSFOF8HKp4/LtOQQBtPkI04nTMVP4zmE5hsVQEZv33h5UKWkUpwQRBTCtfFZTq/Jvw==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.22.0.tgz",
+      "integrity": "sha512-rh25sQ/+5KJSz6+tTRVwbmKpcH9bgkoMw48Vu0xXdTrbPKaO8Kya5E9TM/8+PUZfRtIHU/R1LJJZkoY23awOTg==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.23.0",
+        "@aws-sdk/is-array-buffer": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "@aws-sdk/util-hex-encoding": "3.23.0",
-        "@aws-sdk/util-uri-escape": "3.23.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/util-hex-encoding": "3.22.0",
+        "@aws-sdk/util-uri-escape": "3.22.0",
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -1170,13 +1714,13 @@
       }
     },
     "@aws-sdk/smithy-client": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.23.0.tgz",
-      "integrity": "sha512-wdGuSKVBLaIrC0V9eScWIqYDd50Z/pfAek3OG9lmP4IJLYd4HQJFXTuOXUg9eaJW+qZp3oNXD3clLOyV7WMPQA==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.22.0.tgz",
+      "integrity": "sha512-/xW5ClxSfLUiQFAOFD7H17f57t7tTFNulipSpvI4jWAFyrIbuSAWcR/8f2+iuz2jbteEj1Ik3c5+7AFXPLqgew==",
       "requires": {
-        "@aws-sdk/middleware-stack": "3.23.0",
+        "@aws-sdk/middleware-stack": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -1192,13 +1736,13 @@
       "integrity": "sha512-fyk6HXK1wk83n4fDvsG+ewV+yS4uegepeMNrmLr7iBKjzc/bLckTWk7GKFM5ZaF/9jWyk7o2eKW3C3BltgDrfQ=="
     },
     "@aws-sdk/url-parser": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.23.0.tgz",
-      "integrity": "sha512-uU4BDX0eilGlMuz8qDlNzcH3k4WTZWgMnBuJ9+TdxTXNiLvC+X9HBjVmB2Nr+3mEJhhrRc/8mTrleJvcl60Pyg==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.22.0.tgz",
+      "integrity": "sha512-zHI3GUC0ftsmrFi+9jWhwZu9b7Ol2gQDOEVn161HmAc+SnWyRDUJWLrrrJNoYbMO4SoxJiwoM8LIBv/ydRL74Q==",
       "requires": {
-        "@aws-sdk/querystring-parser": "3.23.0",
+        "@aws-sdk/querystring-parser": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -1209,61 +1753,80 @@
       }
     },
     "@aws-sdk/util-arn-parser": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.23.0.tgz",
-      "integrity": "sha512-J3+/wnC21kbb3UAHo7x31aCZxzIa7GBijt6Q7nad/j2aF38EZtE3SI0aZpD8250Vi+9zsZ4672QDUeSZ5BR5kg==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.22.0.tgz",
+      "integrity": "sha512-png+kNtp8OKC3/3lW/eaxcQgTKKF3O5ICzXzrAQXyuJjXAKzjRn9PrOVt3CDyJPGr2F4/8kAzW3tjE9T8mdMnQ==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       }
     },
     "@aws-sdk/util-base64-browser": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.23.0.tgz",
-      "integrity": "sha512-xlI/qw+uhLJWa3k0mRtRHQ42v5QzsMFEUXScredQMfJ/34qzXyocsG6OHPOTV1I8WSANrxnHR5m1Ae3iU6JuVw==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.22.0.tgz",
+      "integrity": "sha512-z+CpIMB/mhKmiAz5/YPDGJXHNsdsmJoKeKSHWJqwwqpIlQCrwX55DnOGcIggftqOL23OB+K+E0Z/X/NFGRmFEw==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       }
     },
     "@aws-sdk/util-base64-node": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.23.0.tgz",
-      "integrity": "sha512-Kf8JIAUtjrPcD5CJzrig2B5CtegWswUNpW4zBarww/UJhHlp8WzKlCxxA+yNS1ghT0ZMjrRvxPabKDGpkyUfmQ==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.22.0.tgz",
+      "integrity": "sha512-FJln59hxRIDJofQa+O3RC2SsT0xkaju4FmHY3XTR0O+1x/Qo7/SlAzGm8+F3O5fQyk6XWGV6NpY7/jT4iFe/WQ==",
       "requires": {
-        "@aws-sdk/util-buffer-from": "3.23.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/util-buffer-from": "3.22.0",
+        "tslib": "^2.0.0"
       }
     },
     "@aws-sdk/util-body-length-browser": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.23.0.tgz",
-      "integrity": "sha512-Bi6u/5omQbOBSB5BxqVvaPgVplLRjhhSuqK3XAukbeBPh7lcibIBdy7YvbhQyl4i8Hb2QjFnqqfzA0lNBe5eiw==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.22.0.tgz",
+      "integrity": "sha512-CaTvQhp7zq8SYPcCcG1NTYUw/gmz3avxnGGqEsCYU/C3zPczYiqH1e8AixErQSwLKG78lKaDO6DPwmwsheebuw==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       }
     },
     "@aws-sdk/util-body-length-node": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.23.0.tgz",
-      "integrity": "sha512-8kSczloA78mikPaJ742SU9Wpwfcz3HOruoXiP/pOy69UZEsMe4P7zTZI1bo8BAp7j6IFUPCXth9E3UAtkbz+CQ==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.22.0.tgz",
+      "integrity": "sha512-EIfg3PIusUxGwTjTP2O4QVORHkxOw0xub8c1EII++3FPpqWDEl6VUDXbAvJE6SMd0C7UceL6HKjZYKFfx0HbnA==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       }
     },
     "@aws-sdk/util-buffer-from": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.23.0.tgz",
-      "integrity": "sha512-axXy1FvEOM1uECgMPmyHF1S3Hd7JI+BerhhcAlGig0bbqUsZVQUNL9yhOsWreA+nf1v08Ucj8P2SHPCT9Hvpgg==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.22.0.tgz",
+      "integrity": "sha512-9wO2vXY+mH5Fqxf0kxPAJiwKEoy69AA8Srt7B3FeOyhhPAZbSAniS4Kw+I/Ni/5ZyCRyMaKrR31PoDilbana1A==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.23.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/is-array-buffer": "3.22.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-credentials": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.22.0.tgz",
+      "integrity": "sha512-PI4aYgYgLIM8m2zNxXCK/GDlcHUX2akN1QKshM7uPhp5ZsjXVpR//FQ9DsRp+gKFk8VN+4zGo3eIIuJOAVEe3Q==",
+      "requires": {
+        "@aws-sdk/shared-ini-file-loader": "3.22.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.22.0.tgz",
+          "integrity": "sha512-qLTSqjqFc98POGg0W+VsWdDcO/6lMHDB5wAvjULIQ+ra93FybL0jG6eA8Ds1CJ8Ibz446l25P0QZsNHkpKX2EA==",
+          "requires": {
+            "tslib": "^2.0.0"
+          }
+        }
       }
     },
     "@aws-sdk/util-hex-encoding": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.23.0.tgz",
-      "integrity": "sha512-RFDCwNrJMmmPSMVRadxRNePqTXGwtL9s4844x44D0bbGg1TdC42rrg0PRKYkxFL7wd1FbibVQOzciZAvzF+Z+w==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.22.0.tgz",
+      "integrity": "sha512-fCo2URT8kbyEullWjXrmmqtjDmjIAnwMv6T9GFw4enVARUDNArmxGfi4VK/GQKWAGa9Wd2b74tgDH60yG3qAng==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       }
     },
     "@aws-sdk/util-locate-window": {
@@ -1275,21 +1838,21 @@
       }
     },
     "@aws-sdk/util-uri-escape": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.23.0.tgz",
-      "integrity": "sha512-SvQx2E/FDlI5vLT67wwn/k1j2R/G58tYj4Te6GNgEwPGL43X2+7c0+d/WTgndMaRvxSBHZMUTxBYh1HOeU7loA==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.22.0.tgz",
+      "integrity": "sha512-SDeYT3qktYGv/9z6nnVRp3VYm/5S/uea4IPUGQlPyea05uOxe/ysqEW4ogve4ugQVgIbE47OvyoZlwFiFgbkVQ==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.23.0.tgz",
-      "integrity": "sha512-FIjcCdvnUuOBMQgvPZ04Hk28Qy+xJDrtXeWm/7xKJ1K7NRucJWjmC+0OU0uw9A7VOCHf08nk9xniZhAGXs1wJg==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.22.0.tgz",
+      "integrity": "sha512-FnGmHG986MjFV0FW9WV8DF+DBqieo3Dl4KVg7BQSyOAClN3w8XOBvP8YZlxUtYA3zeVXvHRpJjupgRsq8tZ9jw==",
       "requires": {
         "@aws-sdk/types": "3.22.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -1300,13 +1863,13 @@
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.23.0.tgz",
-      "integrity": "sha512-6okok4u13uYRIYdgFZ4dCsowf5vKh+ZxkfVSwvnZO3XAaGEhmIkM3+JKIQjcxLJ+Mt0ssMSJwNMz5oOBSlXPeQ==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.22.0.tgz",
+      "integrity": "sha512-XuAfkTS8Bl++Fp2rbgyIIs3cCVi6DaTmW/a+OztJx2IOVqTIkjruckhBPCf5/v2coy7xZeD8YqpIJUdcY4w+iw==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.23.0",
+        "@aws-sdk/node-config-provider": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -1325,22 +1888,22 @@
       }
     },
     "@aws-sdk/util-utf8-node": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.23.0.tgz",
-      "integrity": "sha512-yao8+8okyfCxRvxZe3GBdO7lJnQEBf3P6rDgleOQD/0DZmMjOQGXCvDd42oagE2TegXhkUnJfVOZU2GqdoR0hg==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.22.0.tgz",
+      "integrity": "sha512-uZPhyt/OiSuFwWzBB/OF6ZUNM5cG7kW1U8Cfa740IKZrCNbawRZipiqkKdffAiVTKF3VfOQEbZCJibiD2BfafQ==",
       "requires": {
-        "@aws-sdk/util-buffer-from": "3.23.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/util-buffer-from": "3.22.0",
+        "tslib": "^2.0.0"
       }
     },
     "@aws-sdk/util-waiter": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.23.0.tgz",
-      "integrity": "sha512-TtCw6OoSrgXLbi1mBn/eicaa3RcJLVm4RdiV1lBQxSX22wyriFP+b1BXRkS9G49rBMciwWu/Xpg8E0Pi79pOnQ==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.22.0.tgz",
+      "integrity": "sha512-LIAwm0UsL829REK6Pqd9HKinC6W9akescqfYlraKd26GBssxfm8HFwHBxHK/roOLgJF0sfgZno2r8eCc/T0nzw==",
       "requires": {
-        "@aws-sdk/abort-controller": "3.23.0",
+        "@aws-sdk/abort-controller": "3.22.0",
         "@aws-sdk/types": "3.22.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@aws-sdk/types": {
@@ -1351,11 +1914,11 @@
       }
     },
     "@aws-sdk/xml-builder": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.23.0.tgz",
-      "integrity": "sha512-5LEGdhQIJtGTwg4dIYyNtpz5QvPcQoxsqJygmj+VB8KLd+mWorH1IOpiL74z0infeK9N+ZFUUPKIzPJa9xLPqw==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.22.0.tgz",
+      "integrity": "sha512-masYbkmAQ0wOcFQ4Cu27mjz14GKLgOe+EDUFY6A8E3x1LrPcCLQAaZ3Q9k7nnipAAEcl/9DruJ+hvlDWG7PkUQ==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.0.0"
       }
     },
     "@babel/code-frame": {

--- a/src/package.json
+++ b/src/package.json
@@ -10,8 +10,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@aws-sdk/client-dynamodb": "^3.23.0",
-    "@aws-sdk/client-s3": "^3.23.0",
+    "@aws-sdk/client-dynamodb": "^3.22.0",
+    "@aws-sdk/client-s3": "^3.22.0",
     "express": "^4.17.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This reverts 321c59fb6e22af7881d96c61d45985b89e5f269e and b8c3174d097bf7ff428923ddd30072378c6998b2.